### PR TITLE
update tuya-iot-py-sdk

### DIFF
--- a/FHEM/bindings/python/fhempy/lib/tuya_cloud/manifest.json
+++ b/FHEM/bindings/python/fhempy/lib/tuya_cloud/manifest.json
@@ -1,5 +1,5 @@
 {
   "requirements": [
-    "tuya-iot-py-sdk==0.5.0"
+    "tuya-iot-py-sdk==0.6.3"
   ]
 }


### PR DESCRIPTION
Due to Python 3.7 support the library can't be updated as long as https://github.com/tuya/tuya-iot-python-sdk/issues/42 isn't fixed.